### PR TITLE
Close coqtop process appropriately

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -14,3 +14,5 @@ the Coq executable is pretty restrictive.
 * Exclude advanced exercises for standard students
 * DONE Remove "-late" suffix from Canvas' names
 * (Maybe?) Link submissions against students' previous files.
+* Handle nested modules more gracefully
+** Detect Module and EndModule to automatically qualify names as necessary?

--- a/src/grader.ml
+++ b/src/grader.ml
@@ -162,10 +162,11 @@ let grade_sub path : unit =
       Printf.sprintf
         "coqtop -I %s -I %s -I %s -require %s -require Submission >> .sf-grader.log 2>&1"
         o.sf_path o.grader_plugin_path workdir assignment in
-    let input, output, _ = Unix.open_process_full coqcom env in
+    let input, output, error = Unix.open_process_full coqcom env in
     let plugin_loader_command = "Declare ML Module \"graderplugin\".\n" in
     output_string output plugin_loader_command;
-    flush output
+    flush output;
+    ignore (Unix.close_process_full (input,output,error))
   end
 
 (** Process an entire zip file with submissions downloaded from

--- a/src/graderplugin.ml
+++ b/src/graderplugin.ml
@@ -2,12 +2,16 @@ open Reductionops
 open Coqlib
 open Environ
 open Global
+open Globnames
 open Libnames
 open Pp
 open Printer
 open Term
+open Universes
 open Util
 
+type exn += Anomaly of (string option * std_ppcmds)
+       
 (** Coq identifiers. { mods = ["Mod1"; ...; "Modn"]; name = "name" }
     represents identifier "Mod1...Modn.name" *)
 type id = {
@@ -101,12 +105,12 @@ let is_conv (t1 : constr) (t2 : constr) : bool =
 
 let has_no_assumptions (id : global_reference) (allowed : Refset.t) : bool =
   let assumptions =
-    constr_of_global id |>
-    Assumptions.assumptions ~add_opaque:false Names.full_transparent_state in
-  Assumptions.ContextObjectMap.for_all (fun obj ty ->
+    Assumptions.assumptions ~add_opaque:false ~add_transparent:false
+                            Names.full_transparent_state id (constr_of_global id) in
+  Printer.ContextObjectMap.for_all (fun obj ty ->
     match obj with
-    | Assumptions.Axiom c ->
-      Refset.exists (fun c' -> is_conv ty (type_of_global c')) allowed
+    | Printer.Axiom (c,_) ->
+      Refset.exists (fun c' -> is_conv ty (constr_of_global c')) allowed
     | _ -> false
   ) assumptions
 
@@ -133,11 +137,11 @@ let check_type (file : string) (id : id) (allowed : Refset.t) : bool =
       Str.global_replace (Str.regexp_string "\n") "" @@
       Str.global_replace (Str.regexp " +") " " @@
       Str.global_replace (Str.regexp_string @@ file ^ ".") "" @@
-        string_of_ppcmds @@ pr_constr @@ type_of_global orig in
+        string_of_ppcmds @@ pr_constr @@ constr_of_global orig in
     let tnew =
       Str.global_replace (Str.regexp_string "\n") "" @@
       Str.global_replace (Str.regexp " +") " " @@
-        string_of_ppcmds @@ pr_constr @@ type_of_global sub in
+        string_of_ppcmds @@ pr_constr @@ constr_of_global sub in
     torig = tnew && has_no_assumptions sub allowed
   | None -> false
 
@@ -154,7 +158,7 @@ let run_test (file : string) (test_fun : id) (id : id) : bool =
 let read_file (path : string) : string =
   let chan = open_in path in
   let nbytes = in_channel_length chan in
-  let s = String.create nbytes in
+  let s = Bytes.create nbytes in
   really_input chan s 0 nbytes;
   close_in chan;
   s


### PR DESCRIPTION
I added a call to make sure the coqtop process closes. My grader script needs this---there was a slight delay generating the .res files, leading to a race in my script.

Sorry for the slightly funny history involving 8.5... I was going to erase those commits, but I figured they embed some knowledge about how to port this script to 8.5 when the time comes. (Though it never did work completely properly.)
